### PR TITLE
Removed RPF link checking

### DIFF
--- a/src/rpf.py
+++ b/src/rpf.py
@@ -36,17 +36,8 @@ class RPFLinkAbstract:
     def _generate_link(self, doi: str) -> str:
         raise NotImplementedError
 
-    def _test(self, link: str) -> bool:
-        if link:
-            test = requests.get(link)
-            link = link if 'application/pdf' in test.headers['Content-Type'] else ''
-        else:
-            link = ''
-        return link
-
     def __call__(self, doi: str) -> str:
-        link = self._generate_link(doi)
-        return self._test(link)
+        return self._generate_link(doi)
 
 
 class RPFLinkEjErEmmMsb(RPFLinkAbstract):


### PR DESCRIPTION
With the embopress.org domain having recently enabled Cloudflare challenges the automated RPF link checking doesn't work anymore.
Any automated, non-obfuscated request to the RPF URLs only returns a challenge to activate Javascript before proceeding.

As the RPF link checking only confirms that the URL format we're using is still valid, there's not much risk in simply deactivating it and checking manually from time to time.